### PR TITLE
Change attribute names: Set.__dict__ and Card.__dict__ match web API

### DIFF
--- a/pokemontcgsdk/card.py
+++ b/pokemontcgsdk/card.py
@@ -17,8 +17,8 @@ class Card(object):
     def __init__(self, response_dict={}):
         self.name = response_dict.get('name')
         self.id = response_dict.get('id')
-        self.national_pokedex_number = response_dict.get('nationalPokedexNumber')
-        self.image_url = response_dict.get('imageUrl')
+        self.nationalPokedexNumber = response_dict.get('nationalPokedexNumber')
+        self.imageUrl = response_dict.get('imageUrl')
         self.types = response_dict.get('types')
         self.subtype = response_dict.get('subtype')
         self.supertype = response_dict.get('supertype')
@@ -28,14 +28,14 @@ class Card(object):
         self.rarity = response_dict.get('rarity')
         self.series = response_dict.get('series')
         self.set = response_dict.get('set')
-        self.set_code = response_dict.get('setCode')
-        self.retreat_cost = response_dict.get('retreatCost')
+        self.setCode = response_dict.get('setCode')
+        self.retreatCost = response_dict.get('retreatCost')
         self.text = response_dict.get('text')
         self.attacks = response_dict.get('attacks')
         self.weaknesses = response_dict.get('weaknesses')
         self.resistances = response_dict.get('resistances')
         self.ability = response_dict.get('ability')
-        self.ancient_trait = response_dict.get('ancientTrait')
+        self.ancientTrait = response_dict.get('ancientTrait')
 
     @staticmethod
     def find(id):

--- a/pokemontcgsdk/config.py
+++ b/pokemontcgsdk/config.py
@@ -8,7 +8,7 @@
 # http://www.opensource.org/licenses/MIT-license
 # Copyright (c) 2016, Andrew Backes <backes.andrew@gmail.com>
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __pypi_packagename__ = "pokemontcgsdk"
 __github_username__ = "PokemonTCG"
 __github_reponame__ = "pokemon-tcg-sdk-python"

--- a/pokemontcgsdk/set.py
+++ b/pokemontcgsdk/set.py
@@ -18,9 +18,9 @@ class Set(object):
         self.name = response_dict.get('name')
         self.code = response_dict.get('code')
         self.series = response_dict.get('series')
-        self.total_cards = response_dict.get('totalCards')
-        self.standard_legal = response_dict.get('standardLegal')
-        self.release_date = response_dict.get('releaseDate')
+        self.totalCards = response_dict.get('totalCards')
+        self.standardLegal = response_dict.get('standardLegal')
+        self.releaseDate = response_dict.get('releaseDate')
 
     @staticmethod
     def find(id):


### PR DESCRIPTION
With this change, [c.__dict__ for c in Card.all()] matches the output of the Web API if it wasn't paginated (camelCase rather than underscore_separated). Consistency is good, yes?