### PR TITLE
Added 'expanded_legal' field to Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Import (Card and Set will be most used)
     series
     total_cards
     standard_legal
+    expanded_legal
     release_date
 
 ### Functions Available

--- a/pokemontcgsdk/set.py
+++ b/pokemontcgsdk/set.py
@@ -20,7 +20,7 @@ class Set(object):
         self.series = response_dict.get('series')
         self.total_cards = response_dict.get('totalCards')
         self.standard_legal = response_dict.get('standardLegal')
-	self.expanded_legal = response_dict.get('expandedLegal')
+        self.expanded_legal = response_dict.get('expandedLegal')
         self.release_date = response_dict.get('releaseDate')
 
     @staticmethod

--- a/pokemontcgsdk/set.py
+++ b/pokemontcgsdk/set.py
@@ -20,6 +20,7 @@ class Set(object):
         self.series = response_dict.get('series')
         self.total_cards = response_dict.get('totalCards')
         self.standard_legal = response_dict.get('standardLegal')
+	self.expanded_legal = response_dict.get('expandedLegal')
         self.release_date = response_dict.get('releaseDate')
 
     @staticmethod

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -22,6 +22,7 @@ class TestSet(unittest.TestCase):
             self.assertEqual('XY', set.series)
             self.assertEqual(114, set.total_cards)
             self.assertEqual(True, set.standard_legal)
+            self.assertEqual(True, set.expanded_legal)
             self.assertEqual('08/03/2016', set.release_date)
             
     def test_where_filters_on_name(self):


### PR DESCRIPTION
I noticed that the `expandedLegal` field exists within the API, but not the Python SDK, so I added it. I'm not quite sure how to run the tests, I don't know a huge amount of Python. Could you give me some pointers so I can just double check it passes before merging? Thanks.