### PR TITLE
Bugfix and dataclass adjustment

### DIFF
--- a/pokemontcgsdk/card.py
+++ b/pokemontcgsdk/card.py
@@ -32,14 +32,15 @@ class Card():
     regulationMark: Optional[str]
     name: str
     nationalPokedexNumbers: Optional[List[int]]
-    number: Optional[str]
+    number: str
     rarity: Optional[str]
+    regulationMark: Optional[str]
     resistances: Optional[List[Resistance]]
     retreatCost: Optional[List[str]]
     rules: Optional[List[str]]
     set: Set
     subtypes: Optional[List[str]]
-    supertype: Optional[str]
+    supertype: str
     tcgplayer: Optional[TCGPlayer]
     types: Optional[List[str]]
     weaknesses: Optional[List[Weakness]]

--- a/pokemontcgsdk/cardmarket.py
+++ b/pokemontcgsdk/cardmarket.py
@@ -24,4 +24,4 @@ class CardmarketPrices():
 class Cardmarket():
     url: str
     updatedAt: str
-    prices: CardmarketPrices
+    prices: Optional[CardmarketPrices]

--- a/pokemontcgsdk/config.py
+++ b/pokemontcgsdk/config.py
@@ -1,4 +1,4 @@
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 __pypi_packagename__ = "pokemontcgsdk"
 __github_username__ = "PokemonTCG"
 __github_reponame__ = "pokemon-tcg-sdk-python"

--- a/pokemontcgsdk/querybuilder.py
+++ b/pokemontcgsdk/querybuilder.py
@@ -46,27 +46,26 @@ class QueryBuilder():
             list of object: List of resource objects
         """
         list = []
-        page = 1
         fetch_all = True
         url = "{}/{}".format(__endpoint__, self.type.RESOURCE)
 
         if 'page' in self.params:
-            page = self.params['page']
             fetch_all = False
+        else:
+            self.params['page'] = 1
 
         while True:
             response = RestClient.get(url, self.params)['data']
             if len(response) > 0:
-                for item in response:
-                    if self.transform:
-                        response = self.transform(item)
-                    list.append(from_dict(self.type, item))
+                if self.transform:
+                    response = [self.transform(i) for i in response]
 
-                if not fetch_all:
-                    break
+                list.extend([from_dict(self.type, item) for item in response])
+
+                if fetch_all:
+                    self.params['page'] += 1
                 else:
-                    page += 1
-                    self.where(page=page)
+                    break
             else:
                 break
 

--- a/pokemontcgsdk/tcgplayer.py
+++ b/pokemontcgsdk/tcgplayer.py
@@ -22,4 +22,4 @@ class TCGPrices():
 class TCGPlayer():
     url: str
     updatedAt: str
-    prices: TCGPrices
+    prices: Optional[TCGPrices]


### PR DESCRIPTION
I went through and ran `Card.all()` and found some interesting things to work through

After investigating all properties... some property definitions could be made non `Optional`, as the offending cards have been resolved. Additionally, some properties need to be made Optional now!

I don't like how the SDKbreaks if these aren't in perfect alignment... but that's something to think about for now... as we just try to stay up to date with it, and run `all_cards` through its paces every release.

Also, there was a subtle bug where requesting all cards would accidentally request each page twice. It was odd, and I can't exactly explain how the original all-loop worked, so I reworked it into something that seems a little clearer, and noticed that I only made one request for each page, as I would expect.

My guess is that the unit tests don't care about how frequently the API is actually being hit, and/or were caching the results making it hard to see the actual duplicate requests being made. I snuck a `print()` call in the loop and saw duplicate requests, and went ahead and fixed it here.

My changes adjust the first request being made for the unit tests, and the cached results. A unit test may hit `/card` and automatically add `page=1` to the request if it isn't there. Cached results in `/fixtures` may need to be cleared out in order for tests to pass.