### PR TITLE
Add evolvesTo field as optional list of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 This is the Pokémon TCG SDK Python implementation. It is a wrapper around the Pokémon TCG API of [pokemontcg.io](http://pokemontcg.io/).
 
 ## Requirements
+
 Python 3 is currently the only supported version for the sdk. More specifically, the package was developed using Python 3.9.
 
 ## Installation
@@ -27,7 +28,6 @@ Import (Card and Set will be most used)
     from pokemontcgsdk import Supertype
     from pokemontcgsdk import Subtype
     from pokemontcgsdk import Rarity
-
 
 ### API-Key
 
@@ -62,6 +62,7 @@ RestClient.configure('12345678-1234-1234-1234-123456789ABC')
     attacks
     convertedRetreatCost
     evolvesFrom
+    evolvesTo
     flavorText
     hp
     id
@@ -104,27 +105,27 @@ RestClient.configure('12345678-1234-1234-1234-123456789ABC')
 #### Filter Cards via query parameters
 
     cards = Card.where(q='set.name:generations supertype:pokemon')
-    
+
 #### Find all cards (will take awhile)
 
     cards = Card.all()
-    
+
 #### Get all cards, but only a specific page of data
 
     cards = Card.where(page=5, pageSize=250)
-    
+
 #### Find a set by code
 
     set = Set.find('base1')
-    
+
 #### Filter sets via query parameters
 
     sets = Set.where(q='legalities.standard:legal')
-    
+
 #### Get all Sets
 
     sets = Set.all()
-    
+
 #### Get all Types
 
     types = Type.all()

--- a/pokemontcgsdk/card.py
+++ b/pokemontcgsdk/card.py
@@ -13,9 +13,10 @@ from pokemontcgsdk.tcgplayer import TCGPlayer
 from pokemontcgsdk.cardmarket import Cardmarket
 from pokemontcgsdk.weakness import Weakness
 
+
 @dataclass
-class Card():
-    RESOURCE = 'cards'
+class Card:
+    RESOURCE = "cards"
 
     abilities: Optional[List[Ability]]
     artist: Optional[str]
@@ -24,6 +25,7 @@ class Card():
     cardmarket: Optional[Cardmarket]
     convertedRetreatCost: Optional[int]
     evolvesFrom: Optional[str]
+    evolvesTo: Optional[List[str]]
     flavorText: Optional[str]
     hp: Optional[str]
     id: str
@@ -59,8 +61,12 @@ class Card():
 
     @staticmethod
     def transform(response):
-        if response.get('tcgplayer', {}).get('prices', {}).get('1stEditionNormal'):
-            response['tcgplayer']['prices']['firstEditionNormal'] = response['tcgplayer']['prices'].pop('1stEditionNormal')
-        if response.get('tcgplayer', {}).get('prices', {}).get('1stEditionHolofoil'):
-            response['tcgplayer']['prices']['firstEditionHolofoil'] = response['tcgplayer']['prices'].pop('1stEditionHolofoil')
+        if response.get("tcgplayer", {}).get("prices", {}).get("1stEditionNormal"):
+            response["tcgplayer"]["prices"]["firstEditionNormal"] = response[
+                "tcgplayer"
+            ]["prices"].pop("1stEditionNormal")
+        if response.get("tcgplayer", {}).get("prices", {}).get("1stEditionHolofoil"):
+            response["tcgplayer"]["prices"]["firstEditionHolofoil"] = response[
+                "tcgplayer"
+            ]["prices"].pop("1stEditionHolofoil")
         return response

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -3,46 +3,52 @@ import vcr
 from pokemontcgsdk import Card
 
 # Python 3.6 Workaround until https://github.com/kevin1024/vcrpy/issues/293 is fixed.
-vcr_connection_request = vcr.stubs.VCRConnection.request 
+vcr_connection_request = vcr.stubs.VCRConnection.request
 vcr.stubs.VCRConnection.request = lambda *args, **kwargs: vcr_connection_request(*args)
+
 
 class TestCard(unittest.TestCase):
     def test_find_returns_card(self):
-        with vcr.use_cassette('fixtures/gardevoir.yaml'):
-            card = Card.find('xy7-54')
-            self.assertEqual('xy7-54', card.id)
-            self.assertEqual('Gardevoir', card.name)
-            self.assertEqual('Pokémon', card.supertype)
-            self.assertEqual(['Stage 2'], card.subtypes)
-            self.assertEqual('130', card.hp)
-            self.assertEqual(['Fairy'], card.types)
-            self.assertEqual('Kirlia', card.evolvesFrom)
+        with vcr.use_cassette("fixtures/gardevoir.yaml"):
+            card = Card.find("xy7-54")
+            self.assertEqual("xy7-54", card.id)
+            self.assertEqual("Gardevoir", card.name)
+            self.assertEqual("Pokémon", card.supertype)
+            self.assertEqual(["Stage 2"], card.subtypes)
+            self.assertEqual("130", card.hp)
+            self.assertEqual(["Fairy"], card.types)
+            self.assertEqual("Kirlia", card.evolvesFrom)
+            self.assertEqual(None, card.evolvesTo)
             self.assertTrue(len(card.abilities) == 1)
             self.assertTrue(len(card.attacks) == 1)
             self.assertTrue(len(card.weaknesses) == 1)
             self.assertTrue(len(card.resistances) == 1)
-            self.assertEqual(['Colorless', 'Colorless'], card.retreatCost)
+            self.assertEqual(["Colorless", "Colorless"], card.retreatCost)
             self.assertEqual(2, card.convertedRetreatCost)
-            self.assertEqual('xy7', card.set.id)
-            self.assertEqual('54', card.number)
-            self.assertEqual('TOKIYA', card.artist)
-            self.assertEqual('Rare Holo', card.rarity)
-            self.assertEqual('It has the power to predict the future. Its power peaks when it is protecting its Trainer.', card.flavorText)
+            self.assertEqual("xy7", card.set.id)
+            self.assertEqual("54", card.number)
+            self.assertEqual("TOKIYA", card.artist)
+            self.assertEqual("Rare Holo", card.rarity)
+            self.assertEqual(
+                "It has the power to predict the future. Its power peaks when it is protecting its Trainer.",
+                card.flavorText,
+            )
             self.assertEqual([282], card.nationalPokedexNumbers)
-            self.assertEqual('https://prices.pokemontcg.io/tcgplayer/xy7-54', card.tcgplayer.url)
+            self.assertEqual(
+                "https://prices.pokemontcg.io/tcgplayer/xy7-54", card.tcgplayer.url
+            )
 
     def test_all_with_params_return_cards(self):
-        with vcr.use_cassette('fixtures/mega_pokemon.yaml'):
-            cards = Card.where(q='supertype:pokemon subtypes:mega')
+        with vcr.use_cassette("fixtures/mega_pokemon.yaml"):
+            cards = Card.where(q="supertype:pokemon subtypes:mega")
             self.assertTrue(len(cards) >= 70)
 
     def test_all_with_page_returns_cards(self):
-        with vcr.use_cassette('fixtures/all_first_page.yaml'):
+        with vcr.use_cassette("fixtures/all_first_page.yaml"):
             cards = Card.where(page=1)
             self.assertEqual(250, len(cards))
 
     def test_all_with_page_and_page_size_returns_card(self):
-        with vcr.use_cassette('fixtures/all_first_page_one_card.yaml'):
+        with vcr.use_cassette("fixtures/all_first_page_one_card.yaml"):
             cards = Card.where(page=1, pageSize=1)
             self.assertEqual(1, len(cards))
-


### PR DESCRIPTION
I noticed this field missing from the SDK so figured I'll add it.

I wasn't quite sure how to test this since the Gardevoir example used in tests is also missing evolution information in the API response, so I made the tests match what the real result would be.

If you'd like me to adjust the tests to also have a case where the evolvesTo is tested in a different way, happy to do that.