### PR TITLE
Changed Various Fields in `card.py` and `set.py` to be optional

### DIFF
--- a/pokemontcgsdk/card.py
+++ b/pokemontcgsdk/card.py
@@ -27,20 +27,20 @@ class Card():
     flavorText: Optional[str]
     hp: Optional[str]
     id: str
-    images: CardImage
-    legalities: Legality
+    images: Optional[CardImage]
+    legalities: Optional[Legality]
     regulationMark: Optional[str]
-    name: str
+    name: Optional[str]
     nationalPokedexNumbers: Optional[List[int]]
-    number: str
+    number: Optional[str]
     rarity: Optional[str]
     regulationMark: Optional[str]
     resistances: Optional[List[Resistance]]
     retreatCost: Optional[List[str]]
     rules: Optional[List[str]]
-    set: Set
+    set: Optional[Set]
     subtypes: Optional[List[str]]
-    supertype: str
+    supertype: Optional[str]
     tcgplayer: Optional[TCGPlayer]
     types: Optional[List[str]]
     weaknesses: Optional[List[Weakness]]

--- a/pokemontcgsdk/set.py
+++ b/pokemontcgsdk/set.py
@@ -10,15 +10,15 @@ class Set():
     RESOURCE = 'sets'
 
     id: str
-    images: SetImage
-    legalities: Legality
-    name: str
-    printedTotal: int
+    images: Optional[SetImage]
+    legalities: Optional[Legality]
+    name: Optional[str]
+    printedTotal: Optional[int]
     ptcgoCode: Optional[str]
-    releaseDate: str
-    series: str
-    total: int
-    updatedAt: str
+    releaseDate: Optional[str]
+    series: Optional[str]
+    total: Optional[int]
+    updatedAt: Optional[str]
 
 
     @staticmethod


### PR DESCRIPTION
For some reason, there are a bunch of fields in `card.py` and `set.py` that are not optional. This becomes an issue when using `where()` with the `select` keyword, as those fields are required in the select. I don't know how to make tests, so no clue if this change will break anything. I also left the id fields as-is, in case they're necessary for something else.